### PR TITLE
slf4j -> log4j2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,6 @@ jar {
 }
 
 shadowJar {
-//    relocate 'org.apache.logging.log4j', 'shadow.org.apache.logging.log4j'
     dependencies {
         exclude(dependency('org.spigotmc:spigot-api:.*'))
         exclude(dependency('org.spigotmc:spigot:.*'))

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-    id "com.github.johnrengelman.shadow" version "1.2.3"
+    id "com.github.johnrengelman.shadow" version "2.0.4"
     id "de.undercouch.download" version "3.1.1"
     id 'org.sonarqube' version '2.5'
 }
@@ -64,7 +64,8 @@ dependencies {
     compile 'org.apache.commons:commons-collections4:4.0'
     compile 'org.apache.commons:commons-lang3:3.7'
 
-    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.11.1'
+    compile 'org.apache.logging.log4j:log4j-api:2.11.1'
 
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.5'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
@@ -111,6 +112,7 @@ jar {
 }
 
 shadowJar {
+//    relocate 'org.apache.logging.log4j', 'shadow.org.apache.logging.log4j'
     dependencies {
         exclude(dependency('org.spigotmc:spigot-api:.*'))
         exclude(dependency('org.spigotmc:spigot:.*'))

--- a/src/main/java/org/popcraft/popcraft/PopCraft.java
+++ b/src/main/java/org/popcraft/popcraft/PopCraft.java
@@ -4,8 +4,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.vavr.collection.Map;
 import io.vavr.collection.Set;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.logging.log4j.LogManager;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -18,7 +17,7 @@ import static java.lang.String.format;
 import static org.popcraft.popcraft.PopCraftModule.*;
 
 //TODO Figure out this MagicMessage business
-@Slf4j
+@Log4j2
 public final class PopCraft extends JavaPlugin {
 
     private static Plugin plugin;

--- a/src/main/java/org/popcraft/popcraft/commands/UpdateScript.java
+++ b/src/main/java/org/popcraft/popcraft/commands/UpdateScript.java
@@ -1,7 +1,7 @@
 package org.popcraft.popcraft.commands;
 
 import com.google.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -10,7 +10,7 @@ import org.popcraft.popcraft.PopCommand;
 import org.popcraft.popcraft.utils.Message;
 
 @PopCommand("update")
-@Slf4j
+@Log4j2
 public class UpdateScript implements CommandExecutor {
 
     private final FileConfiguration config;

--- a/src/main/java/org/popcraft/popcraft/tasks/AnvilListener.java
+++ b/src/main/java/org/popcraft/popcraft/tasks/AnvilListener.java
@@ -1,6 +1,6 @@
 package org.popcraft.popcraft.tasks;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -15,7 +15,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import static org.bukkit.ChatColor.translateAlternateColorCodes;
 
-@Slf4j
+@Log4j2
 public class AnvilListener implements Listener {
 
     @EventHandler

--- a/src/main/java/org/popcraft/popcraft/tasks/BanListener.java
+++ b/src/main/java/org/popcraft/popcraft/tasks/BanListener.java
@@ -1,13 +1,13 @@
 package org.popcraft.popcraft.tasks;
 
 import com.google.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.server.ServerCommandEvent;
 
-@Slf4j
+@Log4j2
 public class BanListener {
 
     private final FileConfiguration config;

--- a/src/main/java/org/popcraft/popcraft/tasks/BookListener.java
+++ b/src/main/java/org/popcraft/popcraft/tasks/BookListener.java
@@ -1,11 +1,11 @@
 package org.popcraft.popcraft.tasks;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerEditBookEvent;
 
-@Slf4j
+@Log4j2
 public class BookListener implements Listener {
 
     @EventHandler

--- a/src/main/java/org/popcraft/popcraft/tasks/ChatFlagListener.java
+++ b/src/main/java/org/popcraft/popcraft/tasks/ChatFlagListener.java
@@ -2,7 +2,7 @@ package org.popcraft.popcraft.tasks;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 import static org.popcraft.popcraft.PopCraftModule.COMMAND_TRIE_KEY;
 import static org.popcraft.popcraft.PopCraftModule.FLAG_TRIE_KEY;
 
-@Slf4j
+@Log4j2
 public class ChatFlagListener implements Listener {
 
     private final Pattern IP_MATCH = Pattern.compile("(?:\\s*\\d+\\s*\\.){3}\\s*\\d+\\s*");

--- a/src/main/java/org/popcraft/popcraft/tasks/SignListener.java
+++ b/src/main/java/org/popcraft/popcraft/tasks/SignListener.java
@@ -1,11 +1,11 @@
 package org.popcraft.popcraft.tasks;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.SignChangeEvent;
 
-@Slf4j
+@Log4j2
 public class SignListener implements Listener {
 
     @EventHandler


### PR DESCRIPTION
Due to classpathing issue with spigot baking log4j2 into the server jar we have to supply our own log4j2 and use their implementation of log4j2. Technically we only need to use the log4j2 api and not core but I currently see no harm of also incuding core as well.